### PR TITLE
default local port must be string not int

### DIFF
--- a/src/SSHTunnel.php
+++ b/src/SSHTunnel.php
@@ -15,7 +15,7 @@ use Retry\RetryProxy;
 class SSHTunnel
 {
 
-    public const DEFAULT_LOCAL_PORT = 33006;
+    public const DEFAULT_LOCAL_PORT = '33006';
 
     public const DEFAULT_SSH_PORT = 22;
 


### PR DESCRIPTION
Pro extractory je potřeba mít port ve stringu - jinak to nevezme DatabaseConfig